### PR TITLE
Use Java 17 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ logged access.
 
 ### Prerequisites
 
-- OpenJDK 11 (with installed ```keytool``` CLI)
-- Maven
+- OpenJDK 17 (with installed ```keytool``` CLI)
+- Maven 3.9.1 or later
 - Authenticate
   to [Github Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry)
+- Docker (if following the guide in this readme)
 
 #### Authenticating to GitHub Packages
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ logged access.
 - Maven 3.9.1 or later
 - Authenticate
   to [Github Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry)
-- Docker (if following the guide in this readme)
+- Optionally: Docker (if following the docker part of the guide)
 
 #### Authenticating to GitHub Packages
 


### PR DESCRIPTION
This project requires Java 17 (not 11) and a version of Maven which runs in Java 17