### PR TITLE
Improve legacy Trustlist endpoints

### DIFF
--- a/owasp/suppressions.xml
+++ b/owasp/suppressions.xml
@@ -12,6 +12,7 @@
     <suppress>
         <notes>H2 is only used for testing, not production</notes>
         <cve>CVE-2022-45868</cve>
+        <cve>CVE-2018-14335</cve>
     </suppress>
     <suppress>
         <notes>False positive. CVE is matching for hutools. OWASP Check matches for json-lib</notes>
@@ -25,5 +26,16 @@
     <suppress>
         <notes>Still WIP</notes>
         <cve>CVE-2022-41862</cve>
+    </suppress>
+    <suppress>
+        <notes>No more recent version available. CVE is not affecting us because we are not using CloudFundry, SPEL and Sessions</notes>
+        <cve>CVE-2023-20873</cve>
+        <cve>CVE-2023-20863</cve>
+        <cve>CVE-2023-20862</cve>
+    </suppress>
+    <suppress>
+        <notes>False positive</notes>
+        <cve>CVE-2020-8908</cve>
+        <cve>CVE-2023-1370</cve>
     </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-starter-parent</artifactId>
-        <version>2022.0.1</version>
+        <version>2022.0.2</version>
         <relativePath/>
     </parent>
 
@@ -47,13 +47,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- dependencies -->
-        <owasp.version>8.0.2</owasp.version>
-        <springdoc.version>1.6.14</springdoc.version>
-        <mapstruct.version>1.5.3.Final</mapstruct.version>
-        <bcpkix.version>1.72</bcpkix.version>
-        <semver4j.version>4.1.1</semver4j.version>
-        <json-schema.version>1.14.1</json-schema.version>
-        <shedlock.version>5.1.0</shedlock.version>
+        <owasp.version>8.2.1</owasp.version>
+        <springdoc.version>1.7.0</springdoc.version>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <bcpkix.version>1.73</bcpkix.version>
+        <semver4j.version>4.3.0</semver4j.version>
+        <json-schema.version>1.14.2</json-schema.version>
+        <shedlock.version>5.2.0</shedlock.version>
         <!-- plugins -->
         <plugin.maven-assembly.version>3.4.2</plugin.maven-assembly.version>
         <plugin.checkstyle.version>3.2.1</plugin.checkstyle.version>
@@ -196,6 +196,17 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-fileupload</groupId>
+                    <artifactId>commons-fileupload</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- dependencies -->
         <owasp.version>8.2.1</owasp.version>
-        <springdoc.version>1.7.0</springdoc.version>
+        <springdoc.version>2.1.0</springdoc.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <bcpkix.version>1.73</bcpkix.version>
         <semver4j.version>4.3.0</semver4j.version>
@@ -261,7 +261,7 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${springdoc.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/eu/europa/ec/dgc/gateway/repository/SignerInformationRepository.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/repository/SignerInformationRepository.java
@@ -30,7 +30,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface SignerInformationRepository extends JpaRepository<SignerInformationEntity, Long> {
 
-    List<SignerInformationEntity> getAllBySourceGatewayIsNull();
+    List<SignerInformationEntity> getAllBySourceGatewayIsNullAndDomainIs(String domain);
 
     @Query("SELECT s FROM SignerInformationEntity s WHERE "
         + "(:ignoreGroup = true OR s.certificateType IN (:group)) AND "
@@ -67,11 +67,11 @@ public interface SignerInformationRepository extends JpaRepository<SignerInforma
     @Transactional
     void deleteByThumbprint(String thumbprint);
 
-    List<SignerInformationEntity> getByCertificateTypeAndSourceGatewayIsNull(
-        SignerInformationEntity.CertificateType type);
+    List<SignerInformationEntity> getByCertificateTypeAndSourceGatewayIsNullAndDomainIs(
+        SignerInformationEntity.CertificateType type, String domain);
 
-    List<SignerInformationEntity> getByCertificateTypeAndCountryAndSourceGatewayIsNull(
-        SignerInformationEntity.CertificateType type, String countryCode);
+    List<SignerInformationEntity> getByCertificateTypeAndCountryAndSourceGatewayIsNullAndDomainIs(
+        SignerInformationEntity.CertificateType type, String countryCode, String domain);
 
     @Transactional
     Long deleteBySourceGatewayGatewayId(String gatewayId);

--- a/src/main/java/eu/europa/ec/dgc/gateway/repository/TrustedPartyRepository.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/repository/TrustedPartyRepository.java
@@ -30,11 +30,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface TrustedPartyRepository extends JpaRepository<TrustedPartyEntity, Long> {
 
-    List<TrustedPartyEntity> getBySourceGatewayIsNull();
+    List<TrustedPartyEntity> getBySourceGatewayIsNullAndDomainIs(String domain);
 
     List<TrustedPartyEntity> getByCountryAndCertificateType(String country, TrustedPartyEntity.CertificateType type);
 
-    List<TrustedPartyEntity> getByCertificateTypeAndSourceGatewayIsNull(TrustedPartyEntity.CertificateType type);
+    List<TrustedPartyEntity> getByCertificateTypeAndSourceGatewayIsNullAndDomainIs(
+        TrustedPartyEntity.CertificateType type, String domain);
 
     Optional<TrustedPartyEntity> getFirstByThumbprintAndCountryAndCertificateType(
         String thumbprint, String country, TrustedPartyEntity.CertificateType type);

--- a/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/TrustListController.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/restapi/controller/TrustListController.java
@@ -99,12 +99,12 @@ public class TrustListController {
             @SecurityRequirement(name = OpenApiConfig.SECURITY_SCHEMA_HASH),
             @SecurityRequirement(name = OpenApiConfig.SECURITY_SCHEMA_DISTINGUISH_NAME)
         },
-        summary = "Returns the full list of trusted certificates.",
+        summary = "Returns the list of trusted certificates of domain DCC.",
         tags = {"Trust Lists"},
         responses = {
             @ApiResponse(
                 responseCode = "200",
-                description = "Returns the full list of trusted parties.",
+                description = "Properties sourceGateway, uuid, domain and version are not present",
                 content = @Content(
                     mediaType = MediaType.APPLICATION_JSON_VALUE,
                     array = @ArraySchema(schema = @Schema(implementation = TrustListDto.class)))),
@@ -139,7 +139,7 @@ public class TrustListController {
             @SecurityRequirement(name = OpenApiConfig.SECURITY_SCHEMA_HASH),
             @SecurityRequirement(name = OpenApiConfig.SECURITY_SCHEMA_DISTINGUISH_NAME)
         },
-        summary = "Returns a filtered list of trusted certificates.",
+        summary = "Returns a filtered list of trusted certificates of domain DCC.",
         tags = {"Trust Lists"},
         parameters = {
             @Parameter(
@@ -152,7 +152,7 @@ public class TrustListController {
         responses = {
             @ApiResponse(
                 responseCode = "200",
-                description = "Returns a filtered list of trusted certificates.",
+                description = "Properties sourceGateway, uuid, domain and version are not present",
                 content = @Content(
                     mediaType = MediaType.APPLICATION_JSON_VALUE,
                     array = @ArraySchema(schema = @Schema(implementation = TrustListDto.class)))),
@@ -200,7 +200,7 @@ public class TrustListController {
             @SecurityRequirement(name = OpenApiConfig.SECURITY_SCHEMA_HASH),
             @SecurityRequirement(name = OpenApiConfig.SECURITY_SCHEMA_DISTINGUISH_NAME)
         },
-        summary = "Returns a filtered list of trusted certificates.",
+        summary = "Returns a filtered list of trusted certificates of domain DCC.",
         tags = {"Trust Lists"},
         parameters = {
             @Parameter(
@@ -219,7 +219,7 @@ public class TrustListController {
         responses = {
             @ApiResponse(
                 responseCode = "200",
-                description = "Returns a filtered list of trusted certificates.",
+                description = "Properties sourceGateway, uuid, domain and version are not present",
                 content = @Content(
                     mediaType = MediaType.APPLICATION_JSON_VALUE,
                     array = @ArraySchema(schema = @Schema(implementation = TrustListDto.class)))),

--- a/src/main/java/eu/europa/ec/dgc/gateway/restapi/mapper/GwTrustListMapper.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/restapi/mapper/GwTrustListMapper.java
@@ -41,10 +41,10 @@ import org.mapstruct.Mapping;
 @Slf4j
 public abstract class GwTrustListMapper {
 
-    @Mapping(source = "certificateType", target = "domain")
+    @Mapping(target = "domain", ignore = true)
     @Mapping(target = "sourceGateway", ignore = true)
     @Mapping(target = "uuid", ignore = true)
-    @Mapping(target = "version", ignore = true)
+    @Mapping(target = "version", expression = "java(null)")
     public abstract TrustListDto trustListToTrustListDto(TrustList trustList);
 
     public abstract List<TrustListDto> trustListToTrustListDto(List<TrustList> trustList);

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/SignerInformationService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/SignerInformationService.java
@@ -74,7 +74,7 @@ public class SignerInformationService {
      * @return List of SignerInformation
      */
     public List<SignerInformationEntity> getNonFederatedSignerInformation() {
-        return signerInformationRepository.getAllBySourceGatewayIsNull();
+        return signerInformationRepository.getAllBySourceGatewayIsNullAndDomainIs("DCC");
     }
 
     /**
@@ -85,7 +85,7 @@ public class SignerInformationService {
      */
     public List<SignerInformationEntity> getNonFederatedSignerInformation(
         SignerInformationEntity.CertificateType type) {
-        return signerInformationRepository.getByCertificateTypeAndSourceGatewayIsNull(type);
+        return signerInformationRepository.getByCertificateTypeAndSourceGatewayIsNullAndDomainIs(type, "DCC");
     }
 
     /**
@@ -98,7 +98,8 @@ public class SignerInformationService {
     public List<SignerInformationEntity> getNonFederatedSignerInformation(
         String countryCode,
         SignerInformationEntity.CertificateType type) {
-        return signerInformationRepository.getByCertificateTypeAndCountryAndSourceGatewayIsNull(type, countryCode);
+        return signerInformationRepository.getByCertificateTypeAndCountryAndSourceGatewayIsNullAndDomainIs(type,
+            countryCode, "DCC");
     }
 
     /**

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/TrustedPartyService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/TrustedPartyService.java
@@ -67,7 +67,7 @@ public class TrustedPartyService {
      */
     public List<TrustedPartyEntity> getNonFederatedTrustedParties() {
 
-        return trustedPartyRepository.getBySourceGatewayIsNull()
+        return trustedPartyRepository.getBySourceGatewayIsNullAndDomainIs("DCC")
             .stream()
             .filter(this::validateCertificateIntegrity)
             .collect(Collectors.toList());
@@ -81,7 +81,7 @@ public class TrustedPartyService {
      */
     public List<TrustedPartyEntity> getNonFederatedTrustedParties(TrustedPartyEntity.CertificateType type) {
 
-        return trustedPartyRepository.getByCertificateTypeAndSourceGatewayIsNull(type)
+        return trustedPartyRepository.getByCertificateTypeAndSourceGatewayIsNullAndDomainIs(type, "DCC")
             .stream()
             .filter(this::validateCertificateIntegrity)
             .collect(Collectors.toList());


### PR DESCRIPTION
Fix: Version and Domain is removed from old Trustlist endpoints
Feat: Only return Certificates with Domain "DCC" at old Trustlist endpoints

closes #55 