### PR TITLE
Fix: Implicit KID isn't used at DID-TrustList generation

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/model/TrustedCertificateTrustList.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/model/TrustedCertificateTrustList.java
@@ -20,6 +20,7 @@
 
 package eu.europa.ec.dgc.gateway.model;
 
+import java.security.cert.X509Certificate;
 import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -51,5 +52,7 @@ public class TrustedCertificateTrustList {
     private String domain;
 
     private Integer version;
+
+    private X509Certificate parsedCertificate;
 
 }

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/TrustListService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/TrustListService.java
@@ -156,7 +156,8 @@ public class TrustListService {
                 ? trustedPartyEntity.getSourceGateway().getGatewayId() : null,
             trustedPartyEntity.getUuid(),
             trustedPartyEntity.getDomain(),
-            trustedPartyEntity.getVersion()
+            trustedPartyEntity.getVersion(),
+            trustedPartyService.getX509CertificateFromEntity(trustedPartyEntity)
         );
     }
 
@@ -174,7 +175,8 @@ public class TrustListService {
                 ? signerInformationEntity.getSourceGateway().getGatewayId() : null,
             signerInformationEntity.getUuid(),
             signerInformationEntity.getDomain(),
-            signerInformationEntity.getVersion()
+            signerInformationEntity.getVersion(),
+            signerInformationService.getX509CertificateFromEntity(signerInformationEntity)
         );
     }
 

--- a/src/test/java/eu/europa/ec/dgc/gateway/service/DidTrustListServiceTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/service/DidTrustListServiceTest.java
@@ -100,6 +100,8 @@ public class DidTrustListServiceTest {
     X509Certificate certUploadDe, certUploadEu, certCscaDe, certCscaEu, certAuthDe, certAuthEu, certDscDe, certDscEu,
         federatedCertDscEx;
 
+    String certDscDeKid;
+
     FederationGatewayEntity federationGateway;
 
     @AfterEach
@@ -130,6 +132,8 @@ public class DidTrustListServiceTest {
         certDscDe =
             CertificateTestUtils.generateCertificate(keyPairGenerator.generateKeyPair(), "DE", "Test", certCscaDe,
                 trustedPartyTestHelper.getPrivateKey(TrustedPartyEntity.CertificateType.AUTHENTICATION, "DE"));
+
+        certDscDeKid = certificateUtils.getCertKid(certDscDe);
         certDscEu =
             CertificateTestUtils.generateCertificate(keyPairGenerator.generateKeyPair(), "EU", "Test", certCscaEu,
                 trustedPartyTestHelper.getPrivateKey(TrustedPartyEntity.CertificateType.AUTHENTICATION, "EU"));
@@ -141,7 +145,7 @@ public class DidTrustListServiceTest {
             certificateUtils.getCertThumbprint(certDscDe),
             Base64.getEncoder().encodeToString(certDscDe.getEncoded()),
             "sig1",
-            "kid1",
+            null, // Don't provide a KID to test that calculated KID will be used
             SignerInformationEntity.CertificateType.DSC,
             null
         ));
@@ -191,7 +195,7 @@ public class DidTrustListServiceTest {
         Assertions.assertEquals("b", parsed.getController());
         Assertions.assertEquals(6, parsed.getVerificationMethod().size());
 
-        assertVerificationMethod(parsed.getVerificationMethod().get(0), "kid1", certDscDe, certCscaDe);
+        assertVerificationMethod(parsed.getVerificationMethod().get(0), certDscDeKid, certDscDe, certCscaDe);
         assertVerificationMethod(parsed.getVerificationMethod().get(1), "kid2", certDscEu, certCscaEu);
         assertVerificationMethod(parsed.getVerificationMethod().get(2), "kid3", federatedCertDscEx, null);
 


### PR DESCRIPTION
When creating the DID Trustlist only the value of KID field of DB entities was used.
This PR fixes the behaviour to use implicit KID (Base64 encoded first 8 bytes of SHA-256 Thumbprint of cert) if it is not overriden with KID field in entity.