### PR TITLE
Fix: Legacy TrustList Endpoint does not work when new Certificate Types were uploaded

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/repository/SignerInformationRepository.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/repository/SignerInformationRepository.java
@@ -30,8 +30,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface SignerInformationRepository extends JpaRepository<SignerInformationEntity, Long> {
 
-    List<SignerInformationEntity> getAllBySourceGatewayIsNullAndDomainIs(String domain);
-
     @Query("SELECT s FROM SignerInformationEntity s WHERE "
         + "(:ignoreGroup = true OR s.certificateType IN (:group)) AND "
         + "(:ignoreCountry = true OR s.country IN (:country)) AND "

--- a/src/main/java/eu/europa/ec/dgc/gateway/repository/TrustedPartyRepository.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/repository/TrustedPartyRepository.java
@@ -30,7 +30,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface TrustedPartyRepository extends JpaRepository<TrustedPartyEntity, Long> {
 
-    List<TrustedPartyEntity> getBySourceGatewayIsNullAndDomainIs(String domain);
+    List<TrustedPartyEntity> getBySourceGatewayIsNullAndDomainIsAndCertificateTypeIsIn(
+        String domain, List<TrustedPartyEntity.CertificateType> types);
 
     List<TrustedPartyEntity> getByCountryAndCertificateType(String country, TrustedPartyEntity.CertificateType type);
 

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/SignerInformationService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/SignerInformationService.java
@@ -70,24 +70,15 @@ public class SignerInformationService {
     private static final String MDC_PROP_UPLOAD_CERT_THUMBPRINT = "uploadCertThumbprint";
     private static final String MDC_PROP_CSCA_CERT_THUMBPRINT = "cscaCertThumbprint";
 
-    /**
-     * Method to query persistence layer for all stored non federated SignerInformation.
-     *
-     * @return List of SignerInformation
-     */
-    public List<SignerInformationEntity> getNonFederatedSignerInformation() {
-        return signerInformationRepository.getAllBySourceGatewayIsNullAndDomainIs("DCC");
-    }
 
     /**
-     * Method to query persistence layer for SignerInformation filtered by Type.
+     * Method to query persistence layer for SignerInformation filtered by Type = DSC.
      *
-     * @param type type to filter for
      * @return List of SignerInformation
      */
-    public List<SignerInformationEntity> getNonFederatedSignerInformation(
-        SignerInformationEntity.CertificateType type) {
-        return signerInformationRepository.getByCertificateTypeAndSourceGatewayIsNullAndDomainIs(type, "DCC");
+    public List<SignerInformationEntity> getNonFederatedEuDscSignerInformation() {
+        return signerInformationRepository.getByCertificateTypeAndSourceGatewayIsNullAndDomainIs(
+            SignerInformationEntity.CertificateType.DSC, "DCC");
     }
 
     /**

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/TrustListService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/TrustListService.java
@@ -53,8 +53,8 @@ public class TrustListService {
      */
     public List<TrustList> getTrustList() {
         return mergeAndConvert(
-            trustedPartyService.getNonFederatedTrustedParties(),
-            signerInformationService.getNonFederatedSignerInformation()
+            trustedPartyService.getNonFederatedEuDscTrustedParties(),
+            signerInformationService.getNonFederatedEuDscSignerInformation()
         );
     }
 
@@ -68,11 +68,11 @@ public class TrustListService {
         if (type == TrustListType.DSC) {
             return mergeAndConvert(
                 Collections.emptyList(),
-                signerInformationService.getNonFederatedSignerInformation(SignerInformationEntity.CertificateType.DSC)
+                signerInformationService.getNonFederatedEuDscSignerInformation()
             );
         } else {
             return mergeAndConvert(
-                trustedPartyService.getNonFederatedTrustedParties(map(type)),
+                trustedPartyService.getNonFederatedEuDscTrustedParties(map(type)),
                 Collections.emptyList()
             );
         }

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/TrustedPartyService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/TrustedPartyService.java
@@ -65,9 +65,11 @@ public class TrustedPartyService {
      *
      * @return List holding the found certificates.
      */
-    public List<TrustedPartyEntity> getNonFederatedTrustedParties() {
+    public List<TrustedPartyEntity> getNonFederatedEuDscTrustedParties() {
 
-        return trustedPartyRepository.getBySourceGatewayIsNullAndDomainIs("DCC")
+        return trustedPartyRepository.getBySourceGatewayIsNullAndDomainIsAndCertificateTypeIsIn("DCC",
+                List.of(TrustedPartyEntity.CertificateType.UPLOAD, TrustedPartyEntity.CertificateType.AUTHENTICATION,
+                    TrustedPartyEntity.CertificateType.CSCA))
             .stream()
             .filter(this::validateCertificateIntegrity)
             .collect(Collectors.toList());
@@ -79,7 +81,7 @@ public class TrustedPartyService {
      * @param type type to filter for.
      * @return List holding the found certificates.
      */
-    public List<TrustedPartyEntity> getNonFederatedTrustedParties(TrustedPartyEntity.CertificateType type) {
+    public List<TrustedPartyEntity> getNonFederatedEuDscTrustedParties(TrustedPartyEntity.CertificateType type) {
 
         return trustedPartyRepository.getByCertificateTypeAndSourceGatewayIsNullAndDomainIs(type, "DCC")
             .stream()

--- a/src/test/java/eu/europa/ec/dgc/gateway/testdata/TrustedPartyTestHelper.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/testdata/TrustedPartyTestHelper.java
@@ -45,19 +45,22 @@ public class TrustedPartyTestHelper {
     private final Map<TrustedPartyEntity.CertificateType, Map<String, String>> hashMap = Map.of(
         TrustedPartyEntity.CertificateType.AUTHENTICATION, new HashMap<>(),
         TrustedPartyEntity.CertificateType.CSCA, new HashMap<>(),
-        TrustedPartyEntity.CertificateType.UPLOAD, new HashMap<>()
+        TrustedPartyEntity.CertificateType.UPLOAD, new HashMap<>(),
+        TrustedPartyEntity.CertificateType.TRUSTANCHOR, new HashMap<>()
     );
 
     private final Map<TrustedPartyEntity.CertificateType, Map<String, X509Certificate>> certificateMap = Map.of(
         TrustedPartyEntity.CertificateType.AUTHENTICATION, new HashMap<>(),
         TrustedPartyEntity.CertificateType.CSCA, new HashMap<>(),
-        TrustedPartyEntity.CertificateType.UPLOAD, new HashMap<>()
+        TrustedPartyEntity.CertificateType.UPLOAD, new HashMap<>(),
+        TrustedPartyEntity.CertificateType.TRUSTANCHOR, new HashMap<>()
     );
 
     private final Map<TrustedPartyEntity.CertificateType, Map<String, PrivateKey>> privateKeyMap = Map.of(
         TrustedPartyEntity.CertificateType.AUTHENTICATION, new HashMap<>(),
         TrustedPartyEntity.CertificateType.CSCA, new HashMap<>(),
-        TrustedPartyEntity.CertificateType.UPLOAD, new HashMap<>()
+        TrustedPartyEntity.CertificateType.UPLOAD, new HashMap<>(),
+        TrustedPartyEntity.CertificateType.TRUSTANCHOR, new HashMap<>()
     );
 
     private final TrustedPartyRepository trustedPartyRepository;


### PR DESCRIPTION
Fix Legacy Trustlist Endpoint to only return EU DCC Types