### PR TITLE
fix: base64urlencode public key parameters

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @ascheibal @f11h @litlfred @tence
+* @ascheibal @f11h @litlfred @tence @karaeth

--- a/src/main/java/eu/europa/ec/dgc/gateway/restapi/dto/did/DidTrustListEntryDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/restapi/dto/did/DidTrustListEntryDto.java
@@ -81,8 +81,8 @@ public class DidTrustListEntryDto {
          */
         public EcPublicKeyJwk(ECPublicKey ecPublicKey, List<String> base64EncodedCertificates) {
             super("EC", base64EncodedCertificates);
-            valueX = Base64.getEncoder().encodeToString(ecPublicKey.getW().getAffineX().toByteArray());
-            valueY = Base64.getEncoder().encodeToString(ecPublicKey.getW().getAffineY().toByteArray());
+            valueX = Base64.getUrlEncoder().encodeToString(ecPublicKey.getW().getAffineX().toByteArray());
+            valueY = Base64.getUrlEncoder().encodeToString(ecPublicKey.getW().getAffineY().toByteArray());
 
             ECNamedCurveSpec curveSpec = (ECNamedCurveSpec) ecPublicKey.getParams();
             switch (curveSpec.getName()) {
@@ -113,8 +113,8 @@ public class DidTrustListEntryDto {
          */
         public RsaPublicKeyJwk(RSAPublicKey rsaPublicKey, List<String> base64EncodedCertificates) {
             super("RSA", base64EncodedCertificates);
-            valueN = Base64.getEncoder().encodeToString(rsaPublicKey.getModulus().toByteArray());
-            valueE = Base64.getEncoder().encodeToString(rsaPublicKey.getPublicExponent().toByteArray());
+            valueN = Base64.getUrlEncoder().encodeToString(rsaPublicKey.getModulus().toByteArray());
+            valueE = Base64.getUrlEncoder().encodeToString(rsaPublicKey.getPublicExponent().toByteArray());
         }
     }
 

--- a/src/test/java/eu/europa/ec/dgc/gateway/service/DidTrustListServiceTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/service/DidTrustListServiceTest.java
@@ -267,17 +267,17 @@ public class DidTrustListServiceTest {
 
         if (dsc.getPublicKey().getAlgorithm().equals(CertificateTestUtils.SignerType.EC.getSigningAlgorithm())) {
             Assertions.assertEquals(((ECPublicKey) dsc.getPublicKey()).getW().getAffineX(),
-                    new BigInteger(Base64.getDecoder().decode(publicKeyJwk.get("x").toString())));
+                    new BigInteger(Base64.getUrlDecoder().decode(publicKeyJwk.get("x").toString())));
             Assertions.assertEquals(((ECPublicKey) dsc.getPublicKey()).getW().getAffineY(),
-                    new BigInteger(Base64.getDecoder().decode(publicKeyJwk.get("y").toString())));
+                    new BigInteger(Base64.getUrlDecoder().decode(publicKeyJwk.get("y").toString())));
             Assertions.assertEquals(CertificateTestUtils.SignerType.EC.getSigningAlgorithm(),
                     publicKeyJwk.get("kty").toString());
             Assertions.assertEquals("P-256", publicKeyJwk.get("crv").toString());
         } else {
             Assertions.assertEquals(((RSAPublicKey) dsc.getPublicKey()).getPublicExponent(),
-                    new BigInteger(Base64.getDecoder().decode(publicKeyJwk.get("e").toString())));
+                    new BigInteger(Base64.getUrlDecoder().decode(publicKeyJwk.get("e").toString())));
             Assertions.assertEquals(((RSAPublicKey) dsc.getPublicKey()).getModulus(),
-                    new BigInteger(Base64.getDecoder().decode(publicKeyJwk.get("n").toString())));
+                    new BigInteger(Base64.getUrlDecoder().decode(publicKeyJwk.get("n").toString())));
             Assertions.assertEquals(CertificateTestUtils.SignerType.RSA.getSigningAlgorithm(),
                     publicKeyJwk.get("kty").toString());
         }


### PR DESCRIPTION
- applies to X/Y for EC
- N/E for RSA
- refers to following spec: [RFC-7517, Section 3](https://www.rfc-editor.org/rfc/rfc7517#section-3), [RFC-7517, Appendix A](https://www.rfc-editor.org/rfc/rfc7517#appendix-A.1)