### PR TITLE
Update application.yml by adding new domain PH4H

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,6 +92,7 @@ dgc:
       - RACSEL-DDVC
       - IPS
       - DICVP
+      - PH4H
   trustlist:
     cron: "* */5 * * * *"
   did:


### PR DESCRIPTION
PH4H = Panamerican Health .... 
This shall succeed the DDVC-Racsel domain

 check how domains may get deprectated in the future

AC

smart trust network gateway accepted PH4H as new supported domain
participant onboarding repository supports new domain
template repository outlines PH4H as supported domain