### PR TITLE
fix:Base64URL encoding for kid

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/service/did/DidTrustListService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/did/DidTrustListService.java
@@ -23,6 +23,7 @@ package eu.europa.ec.dgc.gateway.service.did;
 import com.apicatalog.jsonld.document.JsonDocument;
 import com.danubetech.keyformats.crypto.ByteSigner;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.util.Base64URL;
 import eu.europa.ec.dgc.gateway.config.DgcConfigProperties;
 import eu.europa.ec.dgc.gateway.entity.SignerInformationEntity;
 import eu.europa.ec.dgc.gateway.entity.TrustedIssuerEntity;
@@ -262,7 +263,7 @@ public class DidTrustListService {
                 + SEPARATOR_COLON
                 + getCountryAsLowerCaseAlpha3(cert.getCountry())
                 + SEPARATOR_FRAGMENT
-                + URLEncoder.encode(cert.getKid(), StandardCharsets.UTF_8));
+                + getEncodedKid(cert.getKid()));;
         trustListEntry.setController(configProperties.getDid().getTrustListControllerPrefix()
                 + SEPARATOR_COLON + getCountryAsLowerCaseAlpha3(cert.getCountry()));
         trustListEntry.setPublicKeyJwk(publicKeyJwk);
@@ -281,5 +282,9 @@ public class DidTrustListService {
             .filter(tp -> tp.getParsedCertificate().getSubjectX500Principal()
                 .equals(cert.getParsedCertificate().getIssuerX500Principal()))
             .findFirst();
+    }
+
+    private String getEncodedKid(String kid) {
+        return Base64URL.encode(kid).toString();
     }
 }

--- a/src/test/java/eu/europa/ec/dgc/gateway/service/DidTrustListServiceTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/service/DidTrustListServiceTest.java
@@ -23,6 +23,7 @@ package eu.europa.ec.dgc.gateway.service;
 import static org.mockito.Mockito.doNothing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.util.Base64URL;
 import eu.europa.ec.dgc.gateway.entity.FederationGatewayEntity;
 import eu.europa.ec.dgc.gateway.entity.SignerInformationEntity;
 import eu.europa.ec.dgc.gateway.entity.TrustedPartyEntity;
@@ -220,12 +221,12 @@ public class DidTrustListServiceTest {
         Assertions.assertEquals("b", parsed.getController());
         Assertions.assertEquals(6, parsed.getVerificationMethod().size());
 
-        assertVerificationMethod(getVerificationMethodByKid(parsed.getVerificationMethod(), "c" + ":deu" + "#" + URLEncoder.encode(certDscDeKid, StandardCharsets.UTF_8)),
+        assertVerificationMethod(getVerificationMethodByKid(parsed.getVerificationMethod(), "c" + ":deu" + "#" + getEncodedKid(certDscDeKid)),
             certDscDeKid, certDscDe, certCscaDe, "deu");
-        assertVerificationMethod(getVerificationMethodByKid(parsed.getVerificationMethod(), "c:xeu#kid2"),
-            "kid2", certDscEu, certCscaEu, "xeu");
-        assertVerificationMethod(getVerificationMethodByKid(parsed.getVerificationMethod(), "c:xex#kid3"),
-            "kid3", federatedCertDscEx, null, "xex");
+        assertVerificationMethod(getVerificationMethodByKid(parsed.getVerificationMethod(), "c" + ":xeu" + "#" + getEncodedKid("kid2")),
+                "kid2", certDscEu, certCscaEu, "xeu");
+        assertVerificationMethod(getVerificationMethodByKid(parsed.getVerificationMethod(), "c" + ":xex" + "#" + getEncodedKid("kid3")),
+                "kid3", federatedCertDscEx, null, "xex");
 
         Assertions.assertTrue(parsed.getVerificationMethod().contains("did:trusted:DE:issuer"));
         Assertions.assertTrue(parsed.getVerificationMethod().contains("did:trusted:EU:issuer"));
@@ -261,7 +262,7 @@ public class DidTrustListServiceTest {
         LinkedHashMap jsonNode = (LinkedHashMap) in;
         Assertions.assertEquals("JsonWebKey2020", jsonNode.get("type"));
         Assertions.assertEquals("d" + ":" + country, jsonNode.get("controller"));
-        Assertions.assertEquals("c" + ":" + country + "#" + URLEncoder.encode(kid, StandardCharsets.UTF_8), jsonNode.get("id"));
+        Assertions.assertEquals("c" + ":" + country + "#" + getEncodedKid(kid), jsonNode.get("id"));
 
         LinkedHashMap publicKeyJwk = (LinkedHashMap) jsonNode.get("publicKeyJwk");
 
@@ -312,5 +313,9 @@ public class DidTrustListServiceTest {
             private String nonce;
 
         }
+    }
+
+    private String getEncodedKid(String kid) {
+        return Base64URL.encode(kid).toString();
     }
 }


### PR DESCRIPTION
DDCCGW-706 - TNG: Use base64Url encoded KID instead of URL encoding