### PR TITLE
Updating changes for DDCCGW-678

### DIFF
--- a/src/main/java/eu/europa/ec/dgc/gateway/config/DgcConfigProperties.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/config/DgcConfigProperties.java
@@ -69,6 +69,7 @@ public class DgcConfigProperties {
         private Boolean includeFederated = false;
 
         private AzureConfig azure;
+        private GitConfig git = new GitConfig();
 
         private Map<String, String> contextMapping = new HashMap<>();
 
@@ -178,5 +179,16 @@ public class DgcConfigProperties {
     @Setter
     public static class CountryCodeMap {
         private Map<String, String> virtualCountries = new HashMap<>();
+    }
+
+    @Getter
+    @Setter
+    public static class GitConfig {
+        private String prefix;
+        private String workdir;
+        private String pat;
+        private String url;
+        private String owner;
+        private String branch;
     }
 }

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/did/AzureDidUploader.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/did/AzureDidUploader.java
@@ -34,11 +34,11 @@ import eu.europa.ec.dgc.gateway.config.DgcConfigProperties;
 import java.net.InetSocketAddress;
 import java.text.MessageFormat;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 
-@ConditionalOnProperty(name = "dgc.did.didUploadProvider", havingValue = "azure")
+@ConditionalOnExpression("'${dgc.did.didUploadProvider}'.contains('azure')")
 @Service
 @Slf4j
 public class AzureDidUploader implements DidUploader {

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/did/DidTrustListService.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/did/DidTrustListService.java
@@ -87,7 +87,7 @@ public class DidTrustListService {
 
     private final ByteSigner byteSigner;
 
-    private final DidUploader didUploader;
+    private final DidUploadInvoker didUploadInvoker;
 
     private final ObjectMapper objectMapper;
 
@@ -108,7 +108,7 @@ public class DidTrustListService {
         }
 
         try {
-            didUploader.uploadDid(trustList.getBytes(StandardCharsets.UTF_8));
+            didUploadInvoker.uploadDid(trustList.getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
             log.error("Failed to Upload DID-TrustList: {}", e.getMessage());
             return;
@@ -129,7 +129,8 @@ public class DidTrustListService {
                 }
 
                 try {
-                    didUploader.uploadDid(countryAsSubcontainer, countryTrustList.getBytes(StandardCharsets.UTF_8));
+                    didUploadInvoker
+                    .uploadDid(countryAsSubcontainer, countryTrustList.getBytes(StandardCharsets.UTF_8));
                 } catch (Exception e) {
                     log.error("Failed to Upload DID-TrustList for country {} : {}", country, e.getMessage());
                 }

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/did/DidUploadInvoker.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/did/DidUploadInvoker.java
@@ -1,0 +1,34 @@
+package eu.europa.ec.dgc.gateway.service.did;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DidUploadInvoker {
+    
+    @Autowired
+    List<DidUploader> didUploaders;
+    
+    /**
+     * Method invokes the DID document upload of all the DidUploader implementations. 
+     * @param content DID document in byte array form
+     */
+    public void uploadDid(byte[] content) {
+        for (DidUploader didUploader : didUploaders) {
+            didUploader.uploadDid(content);
+        }
+    }
+    
+    /**
+     * Method invokes the DID document upload of all the DidUploader implementations.
+     * @param subDirectory is a sub folder
+     * @param content DID document in byte array form
+     */
+    public void uploadDid(String subDirectory, byte[] content) {
+        for (DidUploader didUploader : didUploaders) {
+            didUploader.uploadDid(subDirectory, content);
+        }
+    }
+
+}

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/did/GitDidUploader.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/did/GitDidUploader.java
@@ -88,7 +88,19 @@ public class GitDidUploader implements DidUploader {
     }    
 
     @Override
-    public void uploadDid(String subContainer, byte[] content) {        
-        // No implementation required
+    public void uploadDid(String subContainer, byte[] content) {
+        
+        String fileContent = new String(content, StandardCharsets.UTF_8);
+        try {
+            uploadFileToGitHub(configProperties.getDid().getGit().getOwner(), 
+                    configProperties.getDid().getGit().getWorkdir(), 
+                    configProperties.getDid().getGit().getPrefix() + "/" 
+                    + subContainer + "/" + configProperties.getDid().getGit().getUrl(), 
+                    fileContent, 
+                    configProperties.getDid().getGit().getPat());
+        } catch (IOException e) {
+            log.error("Error occured while uploading a file to Github");
+        }
+        log.info("Upload successful");
     }
 }

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/did/GitDidUploader.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/did/GitDidUploader.java
@@ -89,18 +89,7 @@ public class GitDidUploader implements DidUploader {
 
     @Override
     public void uploadDid(String subContainer, byte[] content) {
-        
-        String fileContent = new String(content, StandardCharsets.UTF_8);
-        try {
-            uploadFileToGitHub(configProperties.getDid().getGit().getOwner(), 
-                    configProperties.getDid().getGit().getWorkdir(), 
-                    configProperties.getDid().getGit().getPrefix() + "/" 
-                    + subContainer + "/" + configProperties.getDid().getGit().getUrl(), 
-                    fileContent, 
-                    configProperties.getDid().getGit().getPat());
-        } catch (IOException e) {
-            log.error("Error occured while uploading a file to Github");
-        }
-        log.info("Upload successful");
+              
+        log.trace("Upload not required");
     }
 }

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/did/GitDidUploader.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/did/GitDidUploader.java
@@ -88,19 +88,7 @@ public class GitDidUploader implements DidUploader {
     }    
 
     @Override
-    public void uploadDid(String subContainer, byte[] content) {
-        
-        String fileContent = new String(content, StandardCharsets.UTF_8);
-        try {
-            uploadFileToGitHub(configProperties.getDid().getGit().getOwner(), 
-                    configProperties.getDid().getGit().getWorkdir(), 
-                    configProperties.getDid().getGit().getPrefix() + "/" 
-                    + subContainer + "/" + configProperties.getDid().getGit().getUrl(), 
-                    fileContent, 
-                    configProperties.getDid().getGit().getPat());
-        } catch (IOException e) {
-            log.error("Error occured while uploading a file to Github");
-        }
-        log.info("Upload successful");
+    public void uploadDid(String subContainer, byte[] content) {        
+        // No implementation required
     }
 }

--- a/src/main/java/eu/europa/ec/dgc/gateway/service/did/GitDidUploader.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/service/did/GitDidUploader.java
@@ -1,0 +1,106 @@
+package eu.europa.ec.dgc.gateway.service.did;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.europa.ec.dgc.gateway.config.DgcConfigProperties;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Service;
+
+@ConditionalOnExpression("'${dgc.did.didUploadProvider}'.contains('git')")
+@Service
+@Slf4j
+public class GitDidUploader implements DidUploader {
+    
+    private final DgcConfigProperties configProperties;    
+    
+    public GitDidUploader(DgcConfigProperties configProperties) {
+        this.configProperties = configProperties;        
+    }
+    
+   
+    private Request prepareRequest(String owner, String repo, String path, String content, String token)
+            throws JsonProcessingException {
+        String url = "https://api.github.com/repos/" + owner + "/" + repo + "/contents/" + path;
+
+        // Encode file content to Base64
+        String encodedContent = Base64.getEncoder().encodeToString(content.getBytes(StandardCharsets.UTF_8));
+
+        // Prepare JSON payload
+        Map<String, String> jsonMap = new HashMap<>();
+        jsonMap.put("message", "Automated commit message");
+        jsonMap.put("content", encodedContent);
+        jsonMap.put("branch", configProperties.getDid().getGit().getBranch());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonPayload = objectMapper.writeValueAsString(jsonMap);
+
+        RequestBody body = RequestBody.create(jsonPayload, MediaType.parse("application/json"));
+        Request request = new Request.Builder()
+                .url(url)
+                .header("Authorization", "Bearer " + token)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .put(body)
+                .build();
+        return request;
+    }
+    
+    private void uploadFileToGitHub(String owner, String repo, String path, String content, String token) 
+        throws IOException {
+        OkHttpClient client = new OkHttpClient();
+
+        Request request = prepareRequest(owner, repo, path, content, token);
+
+        Response response = client.newCall(request).execute();
+        if (response.isSuccessful()) {
+            log.info("File uploaded successfully");
+        } else {
+            log.error("Failed to upload file: " + response.message());
+        }
+    }
+
+    @Override
+    public void uploadDid(byte[] content) {        
+        String fileContent = new String(content, StandardCharsets.UTF_8);
+        try {
+            uploadFileToGitHub(configProperties.getDid().getGit().getOwner(), 
+                    configProperties.getDid().getGit().getWorkdir(), 
+                    configProperties.getDid().getGit().getPrefix() + "/" + configProperties.getDid().getGit().getUrl(), 
+                    fileContent, 
+                    configProperties.getDid().getGit().getPat());
+        } catch (IOException e) {
+            log.error("Error occured while uploading a file to Github");
+        }
+        log.info("Upload successful");
+    }    
+
+    @Override
+    public void uploadDid(String subContainer, byte[] content) {
+        
+        String fileContent = new String(content, StandardCharsets.UTF_8);
+        try {
+            uploadFileToGitHub(configProperties.getDid().getGit().getOwner(), 
+                    configProperties.getDid().getGit().getWorkdir(), 
+                    configProperties.getDid().getGit().getPrefix() + "/" 
+                    + subContainer + "/" + configProperties.getDid().getGit().getUrl(), 
+                    fileContent, 
+                    configProperties.getDid().getGit().getPat());
+        } catch (IOException e) {
+            log.error("Error occured while uploading a file to Github");
+        }
+        log.info("Upload successful");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,11 +104,11 @@ dgc:
       "[https://w3id.org/security/suites/jws-2020/v1]": jws-2020_v1.json
     didUploadProvider: azure,git
     git:
-      workdir: tng-cdn-dev
+      workdir: tng-participant-XXA
       prefix: trustlist
       url: did.json
       pat: <personal-access-token-for-git>
-      owner: WorldHealthOrganization
+      owner: shreybansod
       branch: main
   countryCodeMap:
     virtualCountries:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,6 +102,14 @@ dgc:
     contextMapping:
       "[https://www.w3.org/ns/did/v1]": did_v1.json
       "[https://w3id.org/security/suites/jws-2020/v1]": jws-2020_v1.json
+    didUploadProvider: azure,git
+    git:
+      workdir: tng-cdn-dev
+      prefix: trustlist
+      url: did.json
+      pat: <personal-access-token-for-git>
+      owner: WorldHealthOrganization
+      branch: main
   countryCodeMap:
     virtualCountries:
       XA: XXA


### PR DESCRIPTION
The new changes are done in order to upload the trustlist to Github. The changes are done on the similar lines of AzureDidUploader.
A DiUploadInvoker has been introduced as a process controller which will invoke uploadDid method of all the instantiated DidUploader.
The DidUploader are configured on the basis of property 'didUploadProvider'. if the property has value of 'azure' then it will instantiate AzureDidUploader. if the property has value of 'git' then it will instantiate GitDidUploader. if the property has value of 'azure,git' then it will instantiate AzureDidUploader and GitDidUploader both.