### PR TITLE
Supported Domains to be kept as per JIRA DDCCGW-723

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,14 +86,7 @@ dgc:
       - displayURL
     allowedDomains:
       - DCC
-      - DDCC
-      - DIVOC
-      - ICAO
-      - SHC
-      - CRED
-      - RACSEL-DDVC
-      - IPS
-      - DICVP
+      - IPS-PILGRIMAGE
       - PH4H
   trustlist:
     cron: "* */5 * * * *"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,6 +87,7 @@ dgc:
     allowedDomains:
       - DCC
       - IPS-PILGRIMAGE
+      - DICVP
       - PH4H
   trustlist:
     cron: "* */5 * * * *"


### PR DESCRIPTION
Supported Domains to be kept: DCC, IPS-PILGRIMAGE,DICVP PH4H as per JIRA DDCCGW-723 , other domains will be cleaned up.

updates in file(s)
- src/main/resources/application.yml