### PR TITLE
Fix/build docker ci main workflow

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           package-name: ${APP_PACKAGES_URL}
           package-type: container
-          min-versions-to-keep: 5
+          min-versions-to-keep: 3
         env:
           APP_PACKAGES_URL: ghcr.io/worldhealthorganization/ddcc-gateway/ddcc-gateway
           APP_PACKAGES_USERNAME: ${{ github.actor }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -48,17 +48,17 @@ jobs:
           --define app.packages.username="${APP_PACKAGES_USERNAME}"
           --define app.packages.password="${APP_PACKAGES_PASSWORD}";
       - name: Upload ZIP for TST
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: DDCCG001_TST
           path: target/DDCCG001_TST*
       - name: Upload ZIP for ACC
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: DDCCG001_ACC
           path: target/DDCCG001_ACC*
       - name: Upload ZIP for PRD
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: DDCCG001_PRD
           path: target/DDCCG001_PRD*

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -119,9 +119,9 @@ jobs:
         with:
           package-name: ${APP_PACKAGES_URL}
           package-type: container
-          min-versions-to-keep: 3
+          min-versions-to-keep: 5
         env:
-          APP_PACKAGES_URL: ghcr.io/worldhealthorganization/ddcc-gateway/ddcc-gateway
+          APP_PACKAGES_URL: ddcc-gateway%2Fddcc-gateway
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
   license:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -121,7 +121,7 @@ jobs:
           package-type: container
           min-versions-to-keep: 5
         env:
-          APP_PACKAGES_URL: ddcc-gateway%2Fddcc-gateway
+          APP_PACKAGES_URL: ddcc-gateway/ddcc-gateway
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
   license:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -118,6 +118,7 @@ jobs:
       - uses: actions/delete-package-versions@v4
         with:
           package-name: ${APP_PACKAGES_URL}
+          package-type: container
           min-versions-to-keep: 3
         env:
           APP_PACKAGES_URL: ghcr.io/worldhealthorganization/ddcc-gateway/ddcc-gateway

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -121,7 +121,7 @@ jobs:
           package-type: container
           min-versions-to-keep: 5
         env:
-          APP_PACKAGES_URL: ddcc-gateway/ddcc-gateway
+          APP_PACKAGES_URL: ghcr.io/worldhealthorganization/ddcc-gateway/ddcc-gateway
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
   license:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+env:
+  APP_PACKAGES_USERNAME: ${{ github.actor }}
+  APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+  APP_PACKAGES_URL: ghcr.io/worldhealthorganization/ddcc-gateway/ddcc-gateway
 
 jobs:
   build:
@@ -43,9 +47,6 @@ jobs:
           --settings ./settings.xml
           --define app.packages.username="${APP_PACKAGES_USERNAME}"
           --define app.packages.password="${APP_PACKAGES_PASSWORD}";
-        env:
-          APP_PACKAGES_USERNAME: ${{ github.actor }}
-          APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload ZIP for TST
         uses: actions/upload-artifact@v3
         with:
@@ -98,9 +99,6 @@ jobs:
           --settings ./settings.xml
           --define app.packages.username="${APP_PACKAGES_USERNAME}"
           --define app.packages.password="${APP_PACKAGES_PASSWORD}";
-        env:
-          APP_PACKAGES_USERNAME: ${{ github.actor }}
-          APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       - name: docker
         run: >-
           echo "${APP_PACKAGES_PASSWORD}" |
@@ -111,19 +109,11 @@ jobs:
           --file ./Dockerfile
           --tag "${APP_PACKAGES_URL}:${APP_VERSION}";
           docker push "${APP_PACKAGES_URL}:${APP_VERSION}";
-        env:
-          APP_PACKAGES_URL: ghcr.io/worldhealthorganization/ddcc-gateway/ddcc-gateway
-          APP_PACKAGES_USERNAME: ${{ github.actor }}
-          APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/delete-package-versions@v4
+      - uses: actions/delete-package-versions@v5
         with:
           package-name: ${APP_PACKAGES_URL}
           package-type: container
           min-versions-to-keep: 3
-        env:
-          APP_PACKAGES_URL: ghcr.io/worldhealthorganization/ddcc-gateway/ddcc-gateway
-          APP_PACKAGES_USERNAME: ${{ github.actor }}
-          APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
   license:
     runs-on: ubuntu-latest
     steps:
@@ -147,9 +137,6 @@ jobs:
           --settings ./settings.xml
           --define app.packages.username="${APP_PACKAGES_USERNAME}"
           --define app.packages.password="${APP_PACKAGES_PASSWORD}";
-        env:
-          APP_PACKAGES_USERNAME: ${{ github.actor }}
-          APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       - name: Commit and Push changes
         run: |
           git config user.name github-actions

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -111,7 +111,7 @@ jobs:
           docker push "${APP_PACKAGES_URL}:${APP_VERSION}";
       - uses: actions/delete-package-versions@v5
         with:
-          package-name: ${APP_PACKAGES_URL}
+          package-name: ddcc-gateway/ddcc-gateway
           package-type: container
           min-versions-to-keep: 3
   license:


### PR DESCRIPTION
1. Upgrading delete-package-version to v5
2. Upgrading upload-artifact version to v4 (reference: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
3. Eliminating redundant environment variable settings of each job