### PR TITLE
Removed Virtual Entry from image and provision in tng-iac level

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -109,21 +109,21 @@ dgc:
       branch: main
   countryCodeMap:
     virtualCountries:
-      XA: XXA
-      XB: XXB
-      XC: XXC
-      XD: XXD
-      XE: XXE
-      XF: XXF
-      XG: XXG
-      XH: XXH
-      XI: XXI
-      XJ: XXJ
-      XK: XXK
-      XO: XXO
-      XM: XML
-      XL: XCL
-      YK: XYK
+      #XA: XXA
+      #XB: XXB
+      #XC: XXC
+      #XD: XXD
+      #XE: XXE
+      #XF: XXF
+      #XG: XXG
+      #XH: XXH
+      #XI: XXI
+      #XJ: XXJ
+      #XK: XXK
+      #XO: XXO
+      #XM: XML
+      #XL: XCL
+      #YK: XYK
       
       
   cloudmersive:


### PR DESCRIPTION
Removed Virtual Entry from image and provision in tng-iac level for TNG Gateway as env variable on gateway deployment .




Note : Please find update for more inoforation on jira ticket -The KDS and TNG Gateway deployments are provisioning the virtual countries list through the values.yaml file and corresponding ConfigMap. The DEV team Kaushal Kothari / Andreas Scheibal needs to remove the virtual countries list entries from the tng-key-distribution and smart-trust-network-gateway repository application.yaml files, respectively as I don't have privelleges to create new branch on tng-key-distribution repo.

Reference Ticket : https://strive.devops.t-systems.net/jira/browse/WHOGDHCN-1039

Please review and approve subjected # Pull Request for TNG.
